### PR TITLE
fix(AID-1096): Add DATABASE_URI fallback for database connection URL

### DIFF
--- a/src/pg_airman_mcp/server.py
+++ b/src/pg_airman_mcp/server.py
@@ -64,6 +64,7 @@ See main() function for complete CLI argument documentation.
 import argparse
 import asyncio
 import logging
+import os
 import signal
 import sys
 import threading
@@ -73,7 +74,7 @@ from typing import Any, Literal
 import mcp.types as types
 from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
-from pydantic import Field, field_validator, validate_call
+from pydantic import Field, field_validator, model_validator, validate_call
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from pg_airman_mcp.index.dta_calc import DatabaseTuningAdvisor
@@ -131,6 +132,7 @@ class ServerSettings(BaseSettings):
 
     Environment Variables:
         AIRMAN_MCP_DATABASE_URL: PostgreSQL connection string
+        DATABASE_URI: Fallback for database URL if AIRMAN_MCP_DATABASE_URL is not set
         AIRMAN_MCP_ACCESS_MODE: SQL access mode (unrestricted or restricted)
         AIRMAN_MCP_TRANSPORT: Transport type (stdio, sse, streamable-http)
         AIRMAN_MCP_SSE_HOST: SSE server host (default: localhost)
@@ -255,6 +257,13 @@ class ServerSettings(BaseSettings):
         if v.lower() not in allowed:
             raise ValueError(f"transport must be one of {allowed}, got: {v}")
         return v.lower()
+
+    @model_validator(mode="after")
+    def apply_database_url_fallback(self) -> "ServerSettings":
+        """Apply DATABASE_URI fallback if database_url is not set."""
+        if self.database_url is None:
+            self.database_url = os.environ.get("DATABASE_URI")
+        return self
 
     def get_required_scopes(self) -> list[str]:
         """Parse required scopes from comma-separated string."""

--- a/tests/unit/server/test_server_settings.py
+++ b/tests/unit/server/test_server_settings.py
@@ -341,7 +341,6 @@ class TestServerSettingsEnvironmentIntegration:
         with patch.dict(
             os.environ,
             {
-                "DATABASE_URI": "postgresql://old:pass@host/db",
                 "MCP_DATABASE_URL": "postgresql://wrong:pass@host/db",
                 "PG_AIRMAN_ACCESS_MODE": "restricted",
             },
@@ -352,6 +351,31 @@ class TestServerSettingsEnvironmentIntegration:
             # Should use defaults, not old env var names
             assert settings.database_url is None
             assert settings.access_mode == "unrestricted"
+
+    def test_database_uri_fallback(self):
+        """Test that DATABASE_URI is used as fallback when database_url is not set."""
+        with patch.dict(
+            os.environ,
+            {
+                "DATABASE_URI": "postgresql://fallback:pass@host/db",
+            },
+            clear=True,
+        ):
+            settings = ServerSettings()
+            assert settings.database_url == "postgresql://fallback:pass@host/db"
+
+    def test_airman_mcp_database_url_takes_priority_over_database_uri(self):
+        """Test that AIRMAN_MCP_DATABASE_URL takes priority over DATABASE_URI."""
+        with patch.dict(
+            os.environ,
+            {
+                "AIRMAN_MCP_DATABASE_URL": "postgresql://primary:pass@host/db",
+                "DATABASE_URI": "postgresql://fallback:pass@host/db",
+            },
+            clear=True,
+        ):
+            settings = ServerSettings()
+            assert settings.database_url == "postgresql://primary:pass@host/db"
 
     def test_case_insensitive_env_vars(self):
         """Test that environment variables are case-insensitive."""


### PR DESCRIPTION
Adds fallback support for the DATABASE_URI environment variable when AIRMAN_MCP_DATABASE_URL is not set. This enables compatibility with components that use DATABASE_URI as the standard connection string variable.

The only known affected component is upm-langflow which installs pg-airman-mcp when creating new MCP servers and uses `DATABASE_URI` to pass the connection string to the MCP server.